### PR TITLE
Adding CODE_OF_CONDUCT.md back in.

### DIFF
--- a/profile/CODE_OF_CONDUCT.md
+++ b/profile/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Community Code of Conduct
+
+## Overarching Values
+
+* Being respectful of others and of yourself:
+  * Displaying gentleness
+  * Practicing patience
+  * Aiming for mutual-understanding of each other instead of a need to prove yourself as "right"
+* Encouraging curiosity in others and in yourself
+* Developing [a beginner's mindset](https://www.goodreads.com/book/show/402843.Zen_Mind_Beginner_s_Mind) by recognizing that no single person has perfect understanding of anything, and that includes yourself
+* Helping to make this community be a [psychologically safe space](https://hbr.org/2017/08/high-performing-teams-need-psychological-safety-heres-how-to-create-it) to learn, grow and for relationships in
+
+***
+
+## Conduct for all Members
+
+* Anyone is welcome here as long as they agree to uphold the overarching values of this community.
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of technical experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* Please be kind and courteous. There’s no need to act in a mean or rude manner towards anyone. If you think you may have unintentionally done so, please take self-initiative and offer a sincere apology directly to those persons you were mean or rude to.
+* Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right or perfect answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works. Structured and empathetic suggestions are always welcome.
+* We will ask you to leave this community if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes anyone, especially people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the Rust Never Sleeps moderation team immediately. If nobody responds, please directly message Jim Hodapp on Slack. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+_Note: this code of conduct for members is adapted from the official [Rust community's code of conduct](https://www.rust-lang.org/policies/code-of-conduct)._


### PR DESCRIPTION
Git/GitHub got confused with some work I did updating README.md only. This adds the `CODE_OF_CONDUCT.md` file back in under `/profile`.